### PR TITLE
https://github.com/redis-rs/redis-rs/pull/888

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, parse_slots, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
-    cluster_routing::{Redirect, Route, RoutingInfo, Slot, SlotMap},
+    cluster_routing::{Redirect, ResponsePolicy, Route, RoutingInfo, Slot, SlotMap},
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
@@ -119,6 +119,7 @@ enum CmdArg<C> {
         cmd: Arc<Cmd>,
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         routing: Option<RoutingInfo>,
+        response_policy: Option<ResponsePolicy>,
     },
     Pipeline {
         pipeline: Arc<crate::Pipeline>,
@@ -534,48 +535,98 @@ where
         Ok(())
     }
 
-    async fn execute_on_all_nodes(
+    async fn execute_on_multiple_nodes(
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         cmd: &Arc<Cmd>,
         only_primaries: bool,
         core: Core<C>,
+        response_policy: Option<ResponsePolicy>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let read_guard = core.conn_lock.read().await;
-        let results = future::join_all(
-            read_guard
-                .1
-                .all_unique_addresses(only_primaries)
-                .into_iter()
-                .filter_map(|addr| read_guard.0.get(addr).cloned())
-                .map(|conn| {
-                    (async {
-                        let conn = conn.await;
-                        func(conn, cmd.clone()).await
-                    })
-                    .boxed()
-                }),
-        )
-        .await;
+        let connections: Vec<(String, ConnectionFuture<C>)> = read_guard
+            .1
+            .all_unique_addresses(only_primaries)
+            .into_iter()
+            .filter_map(|addr| {
+                read_guard
+                    .0
+                    .get(addr)
+                    .cloned()
+                    .map(|conn| (addr.to_string(), conn))
+            })
+            .collect();
         drop(read_guard);
-        let mut merged_results = Vec::with_capacity(results.len());
 
-        // TODO - we can have better error reporting here if we had an Error variant on Value.
-        for result in results {
-            match result {
-                Ok(response) => match response {
-                    Response::Single(value) => merged_results.push(value),
-                    Response::Multiple(_) => unreachable!(),
-                },
-                Err(_) => {
-                    return (OperationTarget::FanOut, result);
-                }
+        let extract_result = |response| match response {
+            Response::Single(value) => value,
+            Response::Multiple(_) => unreachable!(),
+        };
+
+        let run_func = |(_, conn)| {
+            Box::pin(async move {
+                let conn = conn.await;
+                Ok(extract_result(func(conn, cmd.clone()).await?))
+            })
+        };
+
+        // TODO - once Value::Error will be merged, these will need to be updated to handle this new value.
+        let result = match response_policy {
+            Some(ResponsePolicy::AllSucceeded) => {
+                future::try_join_all(connections.into_iter().map(run_func))
+                    .await
+                    .map(|mut results| results.pop().unwrap()) // unwrap is safe, since at least one function succeeded
+            }
+            Some(ResponsePolicy::OneSucceeded) => {
+                future::select_ok(connections.into_iter().map(run_func))
+                    .await
+                    .map(|(result, _)| result)
+            }
+            Some(ResponsePolicy::OneSucceededNonEmpty) => {
+                future::select_ok(connections.into_iter().map(|tuple| {
+                    Box::pin(async move {
+                        let result = run_func(tuple).await?;
+                        match result {
+                            Value::Nil => Err((ErrorKind::ResponseError, "no value found").into()),
+                            _ => Ok(result),
+                        }
+                    })
+                }))
+                .await
+                .map(|(result, _)| result)
+            }
+            Some(ResponsePolicy::Aggregate(op)) => {
+                future::try_join_all(connections.into_iter().map(run_func))
+                    .await
+                    .and_then(|results| crate::cluster_routing::aggregate(results, op))
+            }
+            Some(ResponsePolicy::AggregateLogical(op)) => {
+                future::try_join_all(connections.into_iter().map(run_func))
+                    .await
+                    .and_then(|results| crate::cluster_routing::logical_aggregate(results, op))
+            }
+            Some(ResponsePolicy::CombineArrays) => {
+                future::try_join_all(connections.into_iter().map(run_func))
+                    .await
+                    .and_then(crate::cluster_routing::combine_array_results)
+            }
+            Some(ResponsePolicy::Special) | None => {
+                // This is our assumption - if there's no coherent way to aggregate the responses, we just map each response to the sender, and pass it to the user.
+                // TODO - once RESP3 is merged, return a map value here.
+                // TODO - once Value::Error is merged, we can use join_all and report separate errors and also pass successes.
+                future::try_join_all(connections.into_iter().map(|(addr, conn)| async move {
+                    let conn = conn.await;
+                    Ok(Value::Bulk(vec![
+                        Value::Data(addr.into_bytes()),
+                        extract_result(func(conn, cmd.clone()).await?),
+                    ]))
+                }))
+                .await
+                .map(Value::Bulk)
             }
         }
+        .map(Response::Single);
 
-        (
-            OperationTarget::FanOut,
-            Ok(Response::Single(Value::Bulk(merged_results))),
-        )
+        (OperationTarget::FanOut, result)
     }
 
     async fn try_cmd_request(
@@ -583,15 +634,18 @@ where
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         redirect: Option<Redirect>,
         routing: Option<RoutingInfo>,
+        response_policy: Option<ResponsePolicy>,
         core: Core<C>,
         asking: bool,
     ) -> (OperationTarget, RedisResult<Response>) {
         let route_option = match routing.as_ref().unwrap_or(&RoutingInfo::Random) {
             RoutingInfo::AllNodes => {
-                return Self::execute_on_all_nodes(func, &cmd, false, core).await
+                return Self::execute_on_multiple_nodes(func, &cmd, false, core, response_policy)
+                    .await
             }
             RoutingInfo::AllMasters => {
-                return Self::execute_on_all_nodes(func, &cmd, true, core).await
+                return Self::execute_on_multiple_nodes(func, &cmd, true, core, response_policy)
+                    .await
             }
             RoutingInfo::Random => None,
             RoutingInfo::SpecificNode(route) => Some(route),
@@ -620,8 +674,22 @@ where
         let asking = matches!(&info.redirect, Some(Redirect::Ask(_)));
 
         match info.cmd {
-            CmdArg::Cmd { cmd, func, routing } => {
-                Self::try_cmd_request(cmd, func, info.redirect, routing, core, asking).await
+            CmdArg::Cmd {
+                cmd,
+                func,
+                routing,
+                response_policy,
+            } => {
+                Self::try_cmd_request(
+                    cmd,
+                    func,
+                    info.redirect,
+                    routing,
+                    response_policy,
+                    core,
+                    asking,
+                )
+                .await
             }
             CmdArg::Pipeline {
                 pipeline,
@@ -994,6 +1062,7 @@ where
                             })
                         },
                         routing: RoutingInfo::for_routable(cmd),
+                        response_policy: RoutingInfo::response_policy(cmd),
                     },
                     sender,
                 })

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -144,6 +144,7 @@ where
                             "CROSSSLOT" => ErrorKind::CrossSlot,
                             "MASTERDOWN" => ErrorKind::MasterDown,
                             "READONLY" => ErrorKind::ReadOnly,
+                            "NOTBUSY" => ErrorKind::NotBusy,
                             code => return make_extension_error(code, pieces.next()),
                         };
                         match pieces.next() {

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -121,6 +121,8 @@ pub enum ErrorKind {
     ExtensionError,
     /// Attempt to write to a read-only server
     ReadOnly,
+    /// Attempted to kill a script/function while they werent' executing
+    NotBusy,
 
     #[cfg(feature = "json")]
     /// Error Serializing a struct to JSON form
@@ -462,6 +464,7 @@ impl RedisError {
             ErrorKind::CrossSlot => Some("CROSSSLOT"),
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
+            ErrorKind::NotBusy => Some("NOTBUSY"),
             _ => match self.repr {
                 ErrorRepr::ExtensionError(ref code, _) => Some(code),
                 _ => None,
@@ -489,6 +492,7 @@ impl RedisError {
             ErrorKind::ExtensionError => "extension error",
             ErrorKind::ClientError => "client error",
             ErrorKind::ReadOnly => "read-only",
+            ErrorKind::NotBusy => "not busy",
             #[cfg(feature = "json")]
             ErrorKind::Serialize => "serializing",
         }
@@ -636,6 +640,7 @@ impl RedisError {
             ErrorKind::InvalidClientConfig => false,
             ErrorKind::CrossSlot => false,
             ErrorKind::ClientError => false,
+            ErrorKind::NotBusy => false,
             #[cfg(feature = "json")]
             ErrorKind::Serialize => false,
         }


### PR DESCRIPTION
this PR is based over https://github.com/nihohit/redis-rs/pull/5.

This change implements the response_policy tip in the async cluster.
https://redis.io/docs/reference/command-tips/#response_policy

This means that the results from fan-out commands will be aggregated
differently, based on the sent command.