### PR TITLE
Add support for multi-shard commands.

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -44,7 +44,7 @@ use std::time::Duration;
 use rand::{seq::IteratorRandom, thread_rng, Rng};
 
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
-use crate::cluster_routing::SlotAddr;
+use crate::cluster_routing::{MultipleNodeRoutingInfo, SingleNodeRoutingInfo, SlotAddr};
 use crate::cmd::{cmd, Cmd};
 use crate::connection::{
     connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
@@ -391,14 +391,16 @@ where
         };
 
         match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => {
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => {
                 let mut rng = thread_rng();
                 Ok(addr_for_slot(Route::new(
                     rng.gen_range(0..SLOT_SIZE),
                     SlotAddr::Master,
                 ))?)
             }
-            Some(RoutingInfo::SpecificNode(route)) => Ok(addr_for_slot(route)?),
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
+                Ok(addr_for_slot(route)?)
+            }
             _ => fail!(UNROUTABLE_ERROR),
         }
     }
@@ -422,7 +424,11 @@ where
         Ok(result)
     }
 
-    fn execute_on_all_nodes<T, F>(&self, mut func: F, only_primaries: bool) -> RedisResult<T>
+    fn execute_on_multiple_nodes<T, F>(
+        &self,
+        mut func: F,
+        routing: MultipleNodeRoutingInfo,
+    ) -> RedisResult<T>
     where
         T: MergeResults,
         F: FnMut(&mut C) -> RedisResult<T>,
@@ -432,7 +438,8 @@ where
         let mut results = HashMap::new();
 
         // TODO: reconnect and shit
-        for addr in slots.all_unique_addresses(only_primaries) {
+        let addresses = slots.addresses_for_multi_routing(&routing);
+        for addr in addresses {
             let addr = addr.to_string();
             if let Some(connection) = connections.get_mut(&addr) {
                 results.insert(addr, func(connection)?);
@@ -450,13 +457,12 @@ where
         F: FnMut(&mut C) -> RedisResult<T>,
     {
         let route = match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => None,
-            Some(RoutingInfo::SpecificNode(route)) => Some(route),
-            Some(RoutingInfo::AllMasters) => {
-                return self.execute_on_all_nodes(func, true);
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
+                Some(route)
             }
-            Some(RoutingInfo::AllNodes) => {
-                return self.execute_on_all_nodes(func, false);
+            Some(RoutingInfo::MultiNode(multi_node_routing)) => {
+                return self.execute_on_multiple_nodes(func, multi_node_routing);
             }
             None => fail!(UNROUTABLE_ERROR),
         };

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -36,7 +36,10 @@ use crate::{
     aio::{ConnectionLike, MultiplexedConnection},
     cluster::{get_connection_info, parse_slots, slot_cmd},
     cluster_client::{ClusterParams, RetryParams},
-    cluster_routing::{Redirect, ResponsePolicy, Route, RoutingInfo, Slot, SlotMap},
+    cluster_routing::{
+        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
+        SingleNodeRoutingInfo, Slot, SlotMap,
+    },
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
@@ -133,10 +136,12 @@ enum CmdArg<C> {
 fn route_pipeline(pipeline: &crate::Pipeline) -> Option<Route> {
     fn route_for_command(cmd: &Cmd) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::Random) => None,
-            Some(RoutingInfo::SpecificNode(route)) => Some(route),
-            Some(RoutingInfo::AllNodes) | Some(RoutingInfo::AllMasters) => None,
-            _ => None,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
+                Some(route)
+            }
+            Some(RoutingInfo::MultiNode(_)) => None,
+            None => None,
         }
     }
 
@@ -538,14 +543,14 @@ where
     async fn execute_on_multiple_nodes(
         func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         cmd: &Arc<Cmd>,
-        only_primaries: bool,
+        routing: &MultipleNodeRoutingInfo,
         core: Core<C>,
         response_policy: Option<ResponsePolicy>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let read_guard = core.conn_lock.read().await;
         let connections: Vec<(String, ConnectionFuture<C>)> = read_guard
             .1
-            .all_unique_addresses(only_primaries)
+            .addresses_for_multi_routing(routing)
             .into_iter()
             .filter_map(|addr| {
                 read_guard
@@ -638,18 +643,24 @@ where
         core: Core<C>,
         asking: bool,
     ) -> (OperationTarget, RedisResult<Response>) {
-        let route_option = match routing.as_ref().unwrap_or(&RoutingInfo::Random) {
-            RoutingInfo::AllNodes => {
-                return Self::execute_on_multiple_nodes(func, &cmd, false, core, response_policy)
-                    .await
+        let route_option = match routing
+            .as_ref()
+            .unwrap_or(&RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
+        {
+            RoutingInfo::MultiNode(multi_node_routing) => {
+                return Self::execute_on_multiple_nodes(
+                    func,
+                    &cmd,
+                    multi_node_routing,
+                    core,
+                    response_policy,
+                )
+                .await
             }
-            RoutingInfo::AllMasters => {
-                return Self::execute_on_multiple_nodes(func, &cmd, true, core, response_policy)
-                    .await
-            }
-            RoutingInfo::Random => None,
-            RoutingInfo::SpecificNode(route) => Some(route),
+            RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random) => None,
+            RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route)) => Some(route),
         };
+
         let (addr, conn) = Self::get_connection(redirect, route_option, core, asking).await;
         let result = func(conn, cmd).await;
         (addr.into(), result)

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -1,5 +1,5 @@
 use std::cmp::min;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::Iterator;
 
 use rand::seq::SliceRandom;
@@ -62,6 +62,8 @@ pub(crate) enum SingleNodeRoutingInfo {
 pub(crate) enum MultipleNodeRoutingInfo {
     AllNodes,
     AllMasters,
+    // Instructions on how to split a multi-slot command (e.g. MGET, MSET) into sub-commands. Each tuple is the route for each subcommand and the indices of the arguments from the original command that should be copied to the subcommand.
+    MultiSlot(Vec<(Route, Vec<usize>)>),
 }
 
 pub(crate) fn aggregate(values: Vec<Value>, op: AggregateOp) -> RedisResult<Value> {
@@ -155,6 +157,31 @@ pub(crate) fn combine_array_results(values: Vec<Value>) -> RedisResult<Value> {
     Ok(Value::Bulk(results))
 }
 
+pub(crate) fn combine_and_sort_array_results<'a>(
+    values: Vec<Value>,
+    sorting_order: impl IntoIterator<Item = &'a Vec<usize>> + ExactSizeIterator,
+) -> RedisResult<Value> {
+    let mut results = Vec::new();
+    results.resize(values.len(), Value::Nil);
+    assert_eq!(values.len(), sorting_order.len());
+
+    for (key_indices, value) in sorting_order.into_iter().zip(values) {
+        match value {
+            Value::Bulk(values) => {
+                assert_eq!(values.len(), key_indices.len());
+                for (index, value) in key_indices.iter().zip(values) {
+                    results[*index - 1] = value;
+                }
+            }
+            _ => {
+                return Err((ErrorKind::TypeError, "expected array of values as response").into());
+            }
+        }
+    }
+
+    Ok(Value::Bulk(results))
+}
+
 fn get_slot(key: &[u8]) -> u16 {
     let key = match get_hashtag(key) {
         Some(tag) => tag,
@@ -173,6 +200,40 @@ fn get_route(is_readonly: bool, key: &[u8]) -> Route {
     }
 }
 
+fn multi_shard<R>(
+    r: &R,
+    cmd: &[u8],
+    first_key_index: usize,
+    has_values: bool,
+) -> Option<RoutingInfo>
+where
+    R: Routable + ?Sized,
+{
+    let is_readonly = is_readonly_cmd(cmd);
+    let mut routes = HashMap::new();
+    let mut index = first_key_index;
+    while let Some(key) = r.arg_idx(index) {
+        let route = get_route(is_readonly, key);
+        let entry = routes.entry(route);
+        let keys = entry.or_insert(Vec::new());
+        keys.push(index);
+
+        if has_values {
+            index += 1;
+            r.arg_idx(index)?; // check that there's a value for the key
+            keys.push(index);
+        }
+        index += 1
+    }
+
+    let mut routes: Vec<(Route, Vec<usize>)> = routes.into_iter().collect();
+    Some(if routes.len() == 1 {
+        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(routes.pop().unwrap().0))
+    } else {
+        RoutingInfo::MultiNode(MultipleNodeRoutingInfo::MultiSlot(routes))
+    })
+}
+
 impl RoutingInfo {
     pub(crate) fn response_policy<R>(r: &R) -> Option<ResponsePolicy>
     where
@@ -187,7 +248,7 @@ impl RoutingInfo {
                 Some(Aggregate(AggregateOp::Sum))
             }
 
-            b"MSETNX" | b"WAIT" => Some(Aggregate(AggregateOp::Min)),
+            b"WAIT" => Some(Aggregate(AggregateOp::Min)),
 
             b"CONFIG SET" | b"FLUSHALL" | b"FLUSHDB" | b"FUNCTION DELETE" | b"FUNCTION FLUSH"
             | b"FUNCTION LOAD" | b"FUNCTION RESTORE" | b"LATENCY RESET" | b"MEMORY PURGE"
@@ -248,7 +309,8 @@ impl RoutingInfo {
                 Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllNodes))
             }
 
-            // TODO - multi shard handling - b"MGET" |b"MSETNX" |b"DEL" |b"EXISTS" |b"UNLINK" |b"TOUCH" |b"MSET"
+            b"MGET" | b"DEL" | b"EXISTS" | b"UNLINK" | b"TOUCH" => multi_shard(r, cmd, 1, false),
+            b"MSET" => multi_shard(r, cmd, 1, true),
             // TODO - special handling - b"SCAN"
             b"SCAN" | b"CLIENT SETNAME" | b"SHUTDOWN" | b"SLAVEOF" | b"REPLICAOF" | b"MOVE"
             | b"BITOP" => None,
@@ -394,7 +456,7 @@ impl Slot {
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub(crate) enum SlotAddr {
     Master,
     Replica,
@@ -504,13 +566,17 @@ impl SlotMap {
             MultipleNodeRoutingInfo::AllMasters => {
                 self.all_unique_addresses(true).into_iter().collect()
             }
+            MultipleNodeRoutingInfo::MultiSlot(routes) => routes
+                .iter()
+                .flat_map(|(route, _)| self.slot_addr_for_route(route))
+                .collect(),
         }
     }
 }
 
 /// Defines the slot and the [`SlotAddr`] to which
 /// a command should be sent
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub(crate) struct Route(u16, SlotAddr);
 
 impl Route {
@@ -774,6 +840,58 @@ mod tests {
                 13, 10, 116, 114, 117, 101, 13, 10, 36, 50, 13, 10, 78, 88, 13, 10, 36, 50, 13, 10,
                 80, 88, 13, 10, 36, 55, 13, 10, 49, 56, 48, 48, 48, 48, 48, 13, 10
             ]).unwrap()), Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route(slot, SlotAddr::Master)))) if slot == 5210));
+    }
+
+    #[test]
+    fn test_multi_shard() {
+        let mut cmd = cmd("DEL");
+        cmd.arg("foo").arg("bar").arg("baz").arg("{bar}vaz");
+        let routing = RoutingInfo::for_routable(&cmd);
+        let mut expected = std::collections::HashMap::new();
+        expected.insert(Route(4813, SlotAddr::Master), vec![3]);
+        expected.insert(Route(5061, SlotAddr::Master), vec![2, 4]);
+        expected.insert(Route(12182, SlotAddr::Master), vec![1]);
+
+        assert!(
+            matches!(routing.clone(), Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::MultiSlot(vec))) if {
+                let routes = vec.clone().into_iter().collect();
+                expected == routes
+            }),
+            "{routing:?}"
+        );
+
+        let mut cmd = crate::cmd("MGET");
+        cmd.arg("foo").arg("bar").arg("baz").arg("{bar}vaz");
+        let routing = RoutingInfo::for_routable(&cmd);
+        let mut expected = std::collections::HashMap::new();
+        expected.insert(Route(4813, SlotAddr::Replica), vec![3]);
+        expected.insert(Route(5061, SlotAddr::Replica), vec![2, 4]);
+        expected.insert(Route(12182, SlotAddr::Replica), vec![1]);
+
+        assert!(
+            matches!(routing.clone(), Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::MultiSlot(vec))) if {
+                let routes = vec.clone().into_iter().collect();
+                expected ==routes
+            }),
+            "{routing:?}"
+        );
+    }
+
+    #[test]
+    fn test_combine_multi_shard_to_single_node_when_all_keys_are_in_same_slot() {
+        let mut cmd = cmd("DEL");
+        cmd.arg("foo").arg("{foo}bar").arg("{foo}baz");
+        let routing = RoutingInfo::for_routable(&cmd);
+
+        assert!(
+            matches!(
+                routing,
+                Some(RoutingInfo::SingleNode(
+                    SingleNodeRoutingInfo::SpecificNode(Route(12182, SlotAddr::Master))
+                ))
+            ),
+            "{routing:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This allows the async cluster client to split keyed commands so that
keys will be grouped by the slot they belong in, and sent only to the
relevant shard.