### PR TITLE
Changed cluster creation to wait for all servers to change their state to OK

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         redis:
           - 6.2.4
-          - 7.0.0
+          - 7.0.12
         rust:
           - stable
           - beta

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
           - 1.60.0
 
     steps:
+
     - name: Cache redis
       id: cache-redis
       uses: actions/cache@v3
@@ -57,7 +58,7 @@ jobs:
       run: |
         echo "$HOME" >> $GITHUB_PATH
 
-    - name: Install latest nightly
+    - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -65,7 +66,8 @@ jobs:
         components: rustfmt
 
     - uses: Swatinem/rust-cache@v1
-    - uses: actions/checkout@v2
+
+    - uses: actions/checkout@v3
 
     - name: Run tests
       run: make test
@@ -138,3 +140,52 @@ jobs:
         run: cargo doc --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
+
+  benchmark:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      redis_ver: 7.0.0
+      rust_ver: stable
+    steps:
+
+    - name: Cache redis
+      id: cache-redis
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/redis-cli
+          ~/redis-server
+        key: ${{ runner.os }}-${{ env.redis_ver }}-redis
+
+    - name: Install redis
+      if: steps.cache-redis.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        wget https://github.com/redis/redis/archive/${{ env.redis_ver }}.tar.gz;
+        tar -xzvf ${{ env.redis_ver }}.tar.gz;
+        pushd redis-${{ env.redis_ver }} && BUILD_TLS=yes make && sudo mv src/redis-server src/redis-cli /usr/bin/ && popd;
+        echo $PATH
+
+    - name: set PATH
+      run: |
+        echo "$HOME" >> $GITHUB_PATH
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_ver }}
+        override: true
+
+    - uses: Swatinem/rust-cache@v1
+
+    - uses: actions/checkout@v3
+
+    - name: Benchmark
+      run: |
+        cargo install critcmp
+        cargo bench --all-features -- --measurement-time 15 --save-baseline changes
+        git fetch
+        git checkout ${{ github.base_ref }} 
+        cargo bench --all-features -- --measurement-time 15 --save-baseline base
+        critcmp base changes

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -42,6 +42,7 @@ futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
+socket2 = { version = "0.4", default-features = false, optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.1.0", optional = true }
@@ -80,7 +81,7 @@ ahash = { version = "0.7.6", optional = true }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["acl", "streams", "geospatial", "script"]
+default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait"]
 geospatial = []
@@ -100,6 +101,7 @@ tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
 connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
+keep-alive = ["socket2"]
 
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -152,6 +152,11 @@ name = "bench_cluster"
 harness = false
 required-features = ["cluster"]
 
+[[bench]]
+name = "bench_cluster_async"
+harness = false
+required-features = ["cluster-async", "tokio-comp"]
+
 [[example]]
 name = "async-multiplexed"
 required-features = ["tokio-comp"]

--- a/redis/benches/bench_cluster_async.rs
+++ b/redis/benches/bench_cluster_async.rs
@@ -1,0 +1,47 @@
+#![allow(clippy::unit_arg)] // want to allow this for `black_box()`
+#![cfg(feature = "cluster")]
+use criterion::{criterion_group, criterion_main, Criterion};
+use redis::RedisError;
+
+use support::*;
+use tokio::runtime::Runtime;
+
+#[path = "../tests/support/mod.rs"]
+mod support;
+
+fn bench_basic(
+    c: &mut Criterion,
+    con: &mut redis::cluster_async::ClusterConnection,
+    runtime: &Runtime,
+) {
+    let mut group = c.benchmark_group("cluster_async_basic");
+    group.sample_size(1_000);
+    group.measurement_time(std::time::Duration::from_secs(30));
+    group.bench_function("set_get_and_del", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(async {
+                    let key = "test_key";
+                    redis::cmd("SET").arg(key).arg(42).query_async(con).await?;
+                    let _: isize = redis::cmd("GET").arg(key).query_async(con).await?;
+                    redis::cmd("DEL").arg(key).query_async(con).await?;
+
+                    Ok::<_, RedisError>(())
+                })
+                .unwrap()
+        })
+    });
+    group.finish();
+}
+
+fn bench_cluster_setup(c: &mut Criterion) {
+    let cluster = TestClusterContext::new(6, 1);
+    cluster.wait_for_cluster_up();
+    let runtime = current_thread_runtime();
+    let mut con = runtime.block_on(cluster.async_connection());
+
+    bench_basic(c, &mut con, &runtime);
+}
+
+criterion_group!(cluster_async_bench, bench_cluster_setup,);
+criterion_main!(cluster_async_bench);

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -34,32 +34,7 @@ use crate::acl;
 pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
     matches!(
         cmd,
-        // @admin
-        b"LASTSAVE" |
-        // @bitmap
-        b"BITCOUNT" | b"BITFIELD_RO" | b"BITPOS" | b"GETBIT" |
-        // @connection
-        b"CLIENT" | b"ECHO" |
-        // @geo
-        b"GEODIST" | b"GEOHASH" | b"GEOPOS" | b"GEORADIUSBYMEMBER_RO" | b"GEORADIUS_RO" | b"GEOSEARCH" |
-        // @hash
-        b"HEXISTS" | b"HGET" | b"HGETALL" | b"HKEYS" | b"HLEN" | b"HMGET" | b"HRANDFIELD" | b"HSCAN" | b"HSTRLEN" | b"HVALS" |
-        // @hyperloglog
-        b"PFCOUNT" |
-        // @keyspace
-        b"DBSIZE" | b"DUMP" | b"EXISTS" | b"EXPIRETIME" | b"KEYS" | b"OBJECT" | b"PEXPIRETIME" | b"PTTL" | b"RANDOMKEY" | b"SCAN" | b"TOUCH" | b"TTL" | b"TYPE" |
-        // @list
-        b"LINDEX" | b"LLEN" | b"LPOS" | b"LRANGE" | b"SORT_RO" |
-        // @scripting
-        b"EVALSHA_RO" | b"EVAL_RO" | b"FCALL_RO" |
-        // @set
-        b"SCARD" | b"SDIFF" | b"SINTER" | b"SINTERCARD" | b"SISMEMBER" | b"SMEMBERS" | b"SMISMEMBER" | b"SRANDMEMBER" | b"SSCAN" | b"SUNION" |
-        // @sortedset
-        b"ZCARD" | b"ZCOUNT" | b"ZDIFF" | b"ZINTER" | b"ZINTERCARD" | b"ZLEXCOUNT" | b"ZMSCORE" | b"ZRANDMEMBER" | b"ZRANGE" | b"ZRANGEBYLEX" | b"ZRANGEBYSCORE" | b"ZRANK" | b"ZREVRANGE" | b"ZREVRANGEBYLEX" | b"ZREVRANGEBYSCORE" | b"ZREVRANK" | b"ZSCAN" | b"ZSCORE" | b"ZUNION" |
-        // @stream
-        b"XINFO" | b"XLEN" | b"XPENDING" | b"XRANGE" | b"XREAD" | b"XREVRANGE" |
-        // @string
-        b"GET" | b"GETRANGE" | b"LCS" | b"MGET" | b"STRALGO" | b"STRLEN" | b"SUBSTR"
+        b"BITCOUNT" | b"BITFIELD_RO" | b"BITPOS" | b"DBSIZE" | b"DUMP" | b"EVALSHA_RO" | b"EVAL_RO" | b"EXISTS" | b"EXPIRETIME" | b"FCALL_RO" | b"GEODIST" | b"GEOHASH" | b"GEOPOS" | b"GEORADIUSBYMEMBER_RO" | b"GEORADIUS_RO" | b"GEOSEARCH" | b"GET" | b"GETBIT" | b"GETRANGE" | b"HEXISTS" | b"HGET" | b"HGETALL" | b"HKEYS" | b"HLEN" | b"HMGET" | b"HRANDFIELD" | b"HSCAN" | b"HSTRLEN" | b"HVALS" | b"KEYS" | b"LCS" | b"LINDEX" | b"LLEN" | b"LOLWUT" | b"LPOS" | b"LRANGE" | b"MEMORY USAGE" | b"MGET" | b"OBJECT ENCODING" | b"OBJECT FREQ" | b"OBJECT IDLETIME" | b"OBJECT REFCOUNT" | b"PEXPIRETIME" | b"PFCOUNT" | b"PTTL" | b"RANDOMKEY" | b"SCAN" | b"SCARD" | b"SDIFF" | b"SINTER" | b"SINTERCARD" | b"SISMEMBER" | b"SMEMBERS" | b"SMISMEMBER" | b"SORT_RO" | b"SRANDMEMBER" | b"SSCAN" | b"STRLEN" | b"SUBSTR" | b"SUNION" | b"TOUCH" | b"TTL" | b"TYPE" | b"XINFO CONSUMERS" | b"XINFO GROUPS" | b"XINFO STREAM" | b"XLEN" | b"XPENDING" | b"XRANGE" | b"XREAD" | b"XREVRANGE" | b"ZCARD" | b"ZCOUNT" | b"ZDIFF" | b"ZINTER" | b"ZINTERCARD" | b"ZLEXCOUNT" | b"ZMSCORE" | b"ZRANDMEMBER" | b"ZRANGE" | b"ZRANGEBYLEX" | b"ZRANGEBYSCORE" | b"ZRANK" | b"ZREVRANGE" | b"ZREVRANGEBYLEX" | b"ZREVRANGEBYSCORE" | b"ZREVRANK" | b"ZSCAN" | b"ZSCORE" | b"ZUNION"
     )
 }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -62,6 +62,7 @@
 //! * `cluster-async`: enables async redis cluster support (optional)
 //! * `tokio-comp`: enables support for tokio (optional)
 //! * `connection-manager`: enables support for automatic reconnection (optional)
+//! * `keep-alive`: enables keep-alive option on socket by means of `socket2` crate (optional)
 //!
 //! ## Connection Parameters
 //!

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -202,7 +202,7 @@ impl RedisCluster {
 }
 
 fn wait_for_status_ok(cluster: &RedisCluster) {
-    'servers: for server in &cluster.servers {
+    'server: for server in &cluster.servers {
         let log_file = RedisServer::log_file(&server.tempdir);
 
         for _ in 1..500 {
@@ -210,7 +210,7 @@ fn wait_for_status_ok(cluster: &RedisCluster) {
                 std::fs::read_to_string(&log_file).expect("Should have been able to read the file");
 
             if contents.contains("Cluster state changed: ok") {
-                break 'servers;
+                continue 'server;
             }
             sleep(Duration::from_millis(20));
         }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -608,6 +608,11 @@ fn test_cluster_fan_out(
     let name = "node";
     let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
     let ports_clone = found_ports.clone();
+    let mut cmd = redis::Cmd::new();
+    for arg in command.split_whitespace() {
+        cmd.arg(arg);
+    }
+    let packed_cmd = cmd.get_packed_command();
     // requests should route to replica
     let MockEnv {
         mut connection,
@@ -618,9 +623,9 @@ fn test_cluster_fan_out(
             .retries(0)
             .read_from_replicas(),
         name,
-        move |cmd: &[u8], port| {
-            respond_startup_with_replica_using_config(name, cmd, slots_config.clone())?;
-            if (cmd[8..]).starts_with(command.as_bytes()) {
+        move |received_cmd: &[u8], port| {
+            respond_startup_with_replica_using_config(name, received_cmd, slots_config.clone())?;
+            if received_cmd == packed_cmd {
                 ports_clone.lock().unwrap().push(port);
                 return Err(Ok(Value::Status("OK".into())));
             }
@@ -628,7 +633,7 @@ fn test_cluster_fan_out(
         },
     );
 
-    let _ = cmd(command).query::<Option<()>>(&mut connection);
+    let _ = cmd.query::<Option<()>>(&mut connection);
     found_ports.lock().unwrap().sort();
     // MockEnv creates 2 mock connections.
     assert_eq!(*found_ports.lock().unwrap(), expected_ports);
@@ -641,13 +646,13 @@ fn test_cluster_fan_out_to_all_primaries() {
 
 #[test]
 fn test_cluster_fan_out_to_all_nodes() {
-    test_cluster_fan_out("ECHO", vec![6379, 6380, 6381, 6382], None);
+    test_cluster_fan_out("CONFIG SET", vec![6379, 6380, 6381, 6382], None);
 }
 
 #[test]
 fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available() {
     test_cluster_fan_out(
-        "ECHO",
+        "CONFIG SET",
         vec![6379, 6381],
         Some(vec![
             MockSlotRange {
@@ -667,7 +672,7 @@ fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available(
 #[test]
 fn test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges() {
     test_cluster_fan_out(
-        "ECHO",
+        "CONFIG SET",
         vec![6379, 6380, 6381, 6382],
         Some(vec![
             MockSlotRange {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -669,6 +669,11 @@ fn test_cluster_fan_out(
     let name = "node";
     let found_ports = Arc::new(std::sync::Mutex::new(Vec::new()));
     let ports_clone = found_ports.clone();
+    let mut cmd = Cmd::new();
+    for arg in command.split_whitespace() {
+        cmd.arg(arg);
+    }
+    let packed_cmd = cmd.get_packed_command();
     // requests should route to replica
     let MockEnv {
         runtime,
@@ -680,9 +685,9 @@ fn test_cluster_fan_out(
             .retries(0)
             .read_from_replicas(),
         name,
-        move |cmd: &[u8], port| {
-            respond_startup_with_replica_using_config(name, cmd, slots_config.clone())?;
-            if (cmd[8..]).starts_with(command.as_bytes()) {
+        move |received_cmd: &[u8], port| {
+            respond_startup_with_replica_using_config(name, received_cmd, slots_config.clone())?;
+            if received_cmd == packed_cmd {
                 ports_clone.lock().unwrap().push(port);
                 return Err(Ok(Value::Status("OK".into())));
             }
@@ -690,7 +695,7 @@ fn test_cluster_fan_out(
         },
     );
 
-    let _ = runtime.block_on(cmd(command).query_async::<_, Option<()>>(&mut connection));
+    let _ = runtime.block_on(cmd.query_async::<_, Option<()>>(&mut connection));
     found_ports.lock().unwrap().sort();
     // MockEnv creates 2 mock connections.
     assert_eq!(*found_ports.lock().unwrap(), expected_ports);
@@ -703,13 +708,13 @@ fn test_cluster_fan_out_to_all_primaries() {
 
 #[test]
 fn test_cluster_fan_out_to_all_nodes() {
-    test_cluster_fan_out("ECHO", vec![6379, 6380, 6381, 6382], None);
+    test_cluster_fan_out("CONFIG SET", vec![6379, 6380, 6381, 6382], None);
 }
 
 #[test]
 fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available() {
     test_cluster_fan_out(
-        "ECHO",
+        "CONFIG SET",
         vec![6379, 6381],
         Some(vec![
             MockSlotRange {
@@ -729,7 +734,7 @@ fn test_cluster_fan_out_out_once_to_each_primary_when_no_replicas_are_available(
 #[test]
 fn test_cluster_fan_out_out_once_even_if_primary_has_multiple_slot_ranges() {
     test_cluster_fan_out(
-        "ECHO",
+        "CONFIG SET",
         vec![6379, 6380, 6381, 6382],
         Some(vec![
             MockSlotRange {


### PR DESCRIPTION
It is now required that the cluster creation waits for all servers to change their state to OK before it returns, rather than waiting only for the first one to change its state.
This change prevents flaky tests due to CLUSTER DOWN errors by not starting testing before all servers are ready.