### PR TITLE
Changed cluster creation to wait for all servers to change their state to OK

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.60.0
+          - 1.63.0
 
     steps:
     - name: Cache redis

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/redis-rs/redis-rs"
 repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis-test"
 license = "BSD-3-Clause"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [lib]
 bench = false

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 readme = "../README.md"
 
 [package.metadata.docs.rs]

--- a/redis/src/geo.rs
+++ b/redis/src/geo.rs
@@ -104,8 +104,10 @@ impl<T: ToRedisArgs> ToRedisArgs for Coord<T> {
 ///
 /// [1]: https://redis.io/commands/georadius
 /// [2]: https://redis.io/commands/georadiusbymember
+#[derive(Default)]
 pub enum RadiusOrder {
     /// Don't sort the results
+    #[default]
     Unsorted,
 
     /// Sort returned items from the nearest to the farthest, relative to the center.
@@ -113,12 +115,6 @@ pub enum RadiusOrder {
 
     /// Sort returned items from the farthest to the nearest, relative to the center.
     Desc,
-}
-
-impl Default for RadiusOrder {
-    fn default() -> RadiusOrder {
-        RadiusOrder::Unsorted
-    }
 }
 
 /// Options for the [GEORADIUS][1] and [GEORADIUSBYMEMBER][2] commands

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -253,18 +253,13 @@ pub struct StreamClaimReply {
 ///
 /// [`xpending`]: ../trait.Commands.html#method.xpending
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum StreamPendingReply {
     /// The stream is empty.
+    #[default]
     Empty,
     /// Data with payload exists in the stream.
     Data(StreamPendingData),
-}
-
-impl Default for StreamPendingReply {
-    fn default() -> StreamPendingReply {
-        StreamPendingReply::Empty
-    }
 }
 
 impl StreamPendingReply {

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -202,7 +202,7 @@ impl RedisCluster {
 }
 
 fn wait_for_status_ok(cluster: &RedisCluster) {
-    'servers: for server in &cluster.servers {
+    'server: for server in &cluster.servers {
         let log_file = RedisServer::log_file(&server.tempdir);
 
         for _ in 1..500 {
@@ -210,7 +210,7 @@ fn wait_for_status_ok(cluster: &RedisCluster) {
                 std::fs::read_to_string(&log_file).expect("Should have been able to read the file");
 
             if contents.contains("Cluster state changed: ok") {
-                break 'servers;
+                continue 'server;
             }
             sleep(Duration::from_millis(20));
         }


### PR DESCRIPTION
It is now required that the cluster creation waits for all servers to change their state to OK before it returns, rather than waiting only for the first one to change its state.
This change prevents flaky tests due to CLUSTER DOWN errors by not starting testing before all servers are ready.