### PR TITLE
Execute multi-node requests using try_request.

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -28,7 +28,7 @@ use std::{
     marker::Unpin,
     mem,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     task::{self, Poll},
 };
 
@@ -102,12 +102,9 @@ where
             .send(Message {
                 cmd: CmdArg::Cmd {
                     cmd: Arc::new(cmd.clone()), // TODO Remove this clone?
-                    func: |mut conn, cmd| {
-                        Box::pin(async move {
-                            conn.req_packed_command(&cmd).await.map(Response::Single)
-                        })
-                    },
-                    routing: routing.or_else(|| RoutingInfo::for_routable(cmd)),
+                    routing: CommandRouting::Route(
+                        routing.or_else(|| RoutingInfo::for_routable(cmd)),
+                    ),
                     response_policy: RoutingInfo::response_policy(cmd),
                 },
                 sender,
@@ -148,13 +145,6 @@ where
                     pipeline: Arc::new(pipeline.clone()), // TODO Remove this clone?
                     offset,
                     count,
-                    func: |mut conn, pipeline, offset, count| {
-                        Box::pin(async move {
-                            conn.req_packed_commands(&pipeline, offset, count)
-                                .await
-                                .map(Response::Multiple)
-                        })
-                    },
                     route: route.or_else(|| route_pipeline(pipeline)),
                 },
                 sender,
@@ -178,6 +168,7 @@ type ConnectionMap<C> = HashMap<String, ConnectionFuture<C>>;
 struct InnerCore<C> {
     conn_lock: RwLock<(ConnectionMap<C>, SlotMap)>,
     cluster_params: ClusterParams,
+    pending_requests: Mutex<Vec<PendingRequest<Response, C>>>,
 }
 
 type Core<C> = Arc<InnerCore<C>>;
@@ -192,22 +183,28 @@ struct ClusterConnInner<C> {
         >,
     >,
     refresh_error: Option<RedisError>,
-    pending_requests: Vec<PendingRequest<Response, C>>,
+}
+
+#[derive(Clone)]
+enum CommandRouting<C> {
+    Route(Option<RoutingInfo>),
+    Connection {
+        addr: String,
+        conn: ConnectionFuture<C>,
+    },
 }
 
 #[derive(Clone)]
 enum CmdArg<C> {
     Cmd {
         cmd: Arc<Cmd>,
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
-        routing: Option<RoutingInfo>,
+        routing: CommandRouting<C>,
         response_policy: Option<ResponsePolicy>,
     },
     Pipeline {
         pipeline: Arc<crate::Pipeline>,
         offset: usize,
         count: usize,
-        func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
         route: Option<Route>,
     },
 }
@@ -330,7 +327,6 @@ enum Next<I, C> {
 impl<F, I, C> Future for Request<F, I, C>
 where
     F: Future<Output = (OperationTarget, RedisResult<I>)>,
-    C: ConnectionLike,
 {
     type Output = Next<I, C>;
 
@@ -428,7 +424,6 @@ where
 impl<F, I, C> Request<F, I, C>
 where
     F: Future<Output = (OperationTarget, RedisResult<I>)>,
-    C: ConnectionLike,
 {
     fn respond(self: Pin<&mut Self>, msg: RedisResult<I>) {
         // If `send` errors the receiver has dropped and thus does not care about the message
@@ -454,12 +449,12 @@ where
         let inner = Arc::new(InnerCore {
             conn_lock: RwLock::new((connections, Default::default())),
             cluster_params,
+            pending_requests: Mutex::new(Vec::new()),
         });
         let mut connection = ClusterConnInner {
             inner,
             in_flight_requests: Default::default(),
             refresh_error: None,
-            pending_requests: Vec::new(),
             state: ConnectionState::PollComplete,
         };
         connection.refresh_slots().await?;
@@ -585,14 +580,13 @@ where
     }
 
     async fn execute_on_multiple_nodes<'a>(
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         cmd: &'a Arc<Cmd>,
         routing: &'a MultipleNodeRoutingInfo,
         core: Core<C>,
         response_policy: Option<ResponsePolicy>,
     ) -> (OperationTarget, RedisResult<Response>) {
         let read_guard = core.conn_lock.read().await;
-        let connections: Vec<_> = read_guard
+        let (receivers, requests): (Vec<_>, Vec<_>) = read_guard
             .1
             .addresses_for_multi_routing(routing)
             .into_iter()
@@ -611,40 +605,61 @@ where
                         }
                         _ => cmd.clone(),
                     };
-                    (addr.to_string(), conn, cmd)
+                    let (sender, receiver) = oneshot::channel();
+                    let addr = addr.to_string();
+                    (
+                        (addr.clone(), receiver),
+                        PendingRequest {
+                            retry: 0,
+                            sender,
+                            info: RequestInfo {
+                                cmd: CmdArg::Cmd {
+                                    cmd,
+                                    routing: CommandRouting::Connection { addr, conn },
+                                    response_policy: None,
+                                },
+                                redirect: None,
+                            },
+                        },
+                    )
                 })
             })
-            .collect();
+            .unzip();
         drop(read_guard);
+        core.pending_requests.lock().unwrap().extend(requests);
 
         let extract_result = |response| match response {
             Response::Single(value) => value,
             Response::Multiple(_) => unreachable!(),
         };
 
-        let run_func = |(_, conn, cmd)| {
-            Box::pin(async move {
-                let conn = conn.await;
-                Ok(extract_result(func(conn, cmd).await?))
-            })
+        let convert_result = |res: Result<RedisResult<Response>, _>| {
+            res.map_err(|_| RedisError::from((ErrorKind::ResponseError, "request wasn't handled")))
+                .and_then(|res| res.map(extract_result))
+        };
+
+        let get_receiver = |(_, receiver): (_, oneshot::Receiver<RedisResult<Response>>)| async {
+            convert_result(receiver.await)
         };
 
         // TODO - once Value::Error will be merged, these will need to be updated to handle this new value.
         let result = match response_policy {
             Some(ResponsePolicy::AllSucceeded) => {
-                future::try_join_all(connections.into_iter().map(run_func))
+                future::try_join_all(receivers.into_iter().map(get_receiver))
                     .await
                     .map(|mut results| results.pop().unwrap()) // unwrap is safe, since at least one function succeeded
             }
-            Some(ResponsePolicy::OneSucceeded) => {
-                future::select_ok(connections.into_iter().map(run_func))
-                    .await
-                    .map(|(result, _)| result)
-            }
+            Some(ResponsePolicy::OneSucceeded) => future::select_ok(
+                receivers
+                    .into_iter()
+                    .map(|tuple| Box::pin(get_receiver(tuple))),
+            )
+            .await
+            .map(|(result, _)| result),
             Some(ResponsePolicy::OneSucceededNonEmpty) => {
-                future::select_ok(connections.into_iter().map(|tuple| {
+                future::select_ok(receivers.into_iter().map(|(_, receiver)| {
                     Box::pin(async move {
-                        let result = run_func(tuple).await?;
+                        let result = convert_result(receiver.await)?;
                         match result {
                             Value::Nil => Err((ErrorKind::ResponseError, "no value found").into()),
                             _ => Ok(result),
@@ -655,17 +670,17 @@ where
                 .map(|(result, _)| result)
             }
             Some(ResponsePolicy::Aggregate(op)) => {
-                future::try_join_all(connections.into_iter().map(run_func))
+                future::try_join_all(receivers.into_iter().map(get_receiver))
                     .await
                     .and_then(|results| crate::cluster_routing::aggregate(results, op))
             }
             Some(ResponsePolicy::AggregateLogical(op)) => {
-                future::try_join_all(connections.into_iter().map(run_func))
+                future::try_join_all(receivers.into_iter().map(get_receiver))
                     .await
                     .and_then(|results| crate::cluster_routing::logical_aggregate(results, op))
             }
             Some(ResponsePolicy::CombineArrays) => {
-                future::try_join_all(connections.into_iter().map(run_func))
+                future::try_join_all(receivers.into_iter().map(get_receiver))
                     .await
                     .and_then(|results| match routing {
                         MultipleNodeRoutingInfo::MultiSlot(vec) => {
@@ -681,12 +696,9 @@ where
                 // This is our assumption - if there's no coherent way to aggregate the responses, we just map each response to the sender, and pass it to the user.
                 // TODO - once RESP3 is merged, return a map value here.
                 // TODO - once Value::Error is merged, we can use join_all and report separate errors and also pass successes.
-                future::try_join_all(connections.into_iter().map(|(addr, conn, cmd)| async move {
-                    let conn = conn.await;
-                    Ok(Value::Bulk(vec![
-                        Value::Data(addr.into_bytes()),
-                        extract_result(func(conn, cmd).await?),
-                    ]))
+                future::try_join_all(receivers.into_iter().map(|(addr, receiver)| async move {
+                    let result = convert_result(receiver.await)?;
+                    Ok(Value::Bulk(vec![Value::Data(addr.into_bytes()), result]))
                 }))
                 .await
                 .map(Value::Bulk)
@@ -699,20 +711,30 @@ where
 
     async fn try_cmd_request(
         cmd: Arc<Cmd>,
-        func: fn(C, Arc<Cmd>) -> RedisFuture<'static, Response>,
         redirect: Option<Redirect>,
-        routing: Option<RoutingInfo>,
+        routing: CommandRouting<C>,
         response_policy: Option<ResponsePolicy>,
         core: Core<C>,
         asking: bool,
     ) -> (OperationTarget, RedisResult<Response>) {
+        let routing = match routing {
+            CommandRouting::Route(routing) => routing,
+            CommandRouting::Connection { addr, conn } => {
+                if !asking {
+                    let mut conn = conn.await;
+                    let result = conn.req_packed_command(&cmd).await.map(Response::Single);
+                    return (addr.into(), result);
+                }
+                None
+            }
+        };
+
         let route_option = match routing
             .as_ref()
             .unwrap_or(&RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
         {
             RoutingInfo::MultiNode(multi_node_routing) => {
                 return Self::execute_on_multiple_nodes(
-                    func,
                     &cmd,
                     multi_node_routing,
                     core,
@@ -724,8 +746,8 @@ where
             RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route)) => Some(route),
         };
 
-        let (addr, conn) = Self::get_connection(redirect, route_option, core, asking).await;
-        let result = func(conn, cmd).await;
+        let (addr, mut conn) = Self::get_connection(redirect, route_option, core, asking).await;
+        let result = conn.req_packed_command(&cmd).await.map(Response::Single);
         (addr.into(), result)
     }
 
@@ -733,11 +755,13 @@ where
         pipeline: Arc<crate::Pipeline>,
         offset: usize,
         count: usize,
-        func: fn(C, Arc<crate::Pipeline>, usize, usize) -> RedisFuture<'static, Response>,
         conn: impl Future<Output = (String, C)>,
     ) -> (OperationTarget, RedisResult<Response>) {
-        let (addr, conn) = conn.await;
-        let result = func(conn, pipeline, offset, count).await;
+        let (addr, mut conn) = conn.await;
+        let result = conn
+            .req_packed_commands(&pipeline, offset, count)
+            .await
+            .map(Response::Multiple);
         (OperationTarget::Node { address: addr }, result)
     }
 
@@ -750,33 +774,22 @@ where
         match info.cmd {
             CmdArg::Cmd {
                 cmd,
-                func,
                 routing,
                 response_policy,
             } => {
-                Self::try_cmd_request(
-                    cmd,
-                    func,
-                    info.redirect,
-                    routing,
-                    response_policy,
-                    core,
-                    asking,
-                )
-                .await
+                Self::try_cmd_request(cmd, info.redirect, routing, response_policy, core, asking)
+                    .await
             }
             CmdArg::Pipeline {
                 pipeline,
                 offset,
                 count,
-                func,
                 route,
             } => {
                 Self::try_pipeline_request(
                     pipeline,
                     offset,
                     count,
-                    func,
                     Self::get_connection(info.redirect, route.as_ref(), core, asking),
                 )
                 .await
@@ -872,8 +885,9 @@ where
     fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
         let mut poll_flush_action = PollFlushAction::None;
 
-        if !self.pending_requests.is_empty() {
-            let mut pending_requests = mem::take(&mut self.pending_requests);
+        let mut pending_requests_guard = self.inner.pending_requests.lock().unwrap();
+        if !pending_requests_guard.is_empty() {
+            let mut pending_requests = mem::take(&mut *pending_requests_guard);
             for request in pending_requests.drain(..) {
                 // Drop the request if noone is waiting for a response to free up resources for
                 // requests callers care about (load shedding). It will be ambigous whether the
@@ -889,8 +903,9 @@ where
                     future: RequestState::Future { future },
                 }));
             }
-            self.pending_requests = pending_requests;
+            *pending_requests_guard = pending_requests;
         }
+        drop(pending_requests_guard);
 
         loop {
             let result = match Pin::new(&mut self.in_flight_requests).poll_next(cx) {
@@ -931,7 +946,7 @@ where
                             poll_flush_action.change_state(PollFlushAction::RebuildSlots)
                         }
                     };
-                    self.pending_requests.push(request);
+                    self.inner.pending_requests.lock().unwrap().push(request);
                 }
             }
         }
@@ -958,7 +973,7 @@ where
                 (*request)
                     .as_mut()
                     .respond(Err(self.refresh_error.take().unwrap()));
-            } else if let Some(request) = self.pending_requests.pop() {
+            } else if let Some(request) = self.inner.pending_requests.lock().unwrap().pop() {
                 let _ = request.sender.send(Err(self.refresh_error.take().unwrap()));
             }
         }
@@ -1038,18 +1053,22 @@ where
         }
     }
 
-    fn start_send(mut self: Pin<&mut Self>, msg: Message<C>) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, msg: Message<C>) -> Result<(), Self::Error> {
         trace!("start_send");
         let Message { cmd, sender } = msg;
 
         let redirect = None;
         let info = RequestInfo { cmd, redirect };
 
-        self.pending_requests.push(PendingRequest {
-            retry: 0,
-            sender,
-            info,
-        });
+        self.inner
+            .pending_requests
+            .lock()
+            .unwrap()
+            .push(PendingRequest {
+                retry: 0,
+                sender,
+                info,
+            });
         Ok(())
     }
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "cluster-async")]
 mod support;
 use std::sync::{
-    atomic::{self, AtomicI32},
+    atomic::{self, AtomicI32, AtomicU16},
     atomic::{AtomicBool, Ordering},
     Arc,
 };
@@ -1174,6 +1174,53 @@ fn test_cluster_split_multi_shard_command_and_combine_arrays_of_values() {
         .block_on(cmd.query_async::<_, Vec<String>>(&mut connection))
         .unwrap();
     assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6380"]);
+}
+
+#[test]
+fn test_cluster_handle_asking_error_in_split_multi_shard_command() {
+    let name = "test_cluster_handle_asking_error_in_split_multi_shard_command";
+    let mut cmd = cmd("MGET");
+    cmd.arg("foo").arg("bar").arg("baz");
+    let asking_called = Arc::new(AtomicU16::new(0));
+    let asking_called_cloned = asking_called.clone();
+    let MockEnv {
+        runtime,
+        async_connection: mut connection,
+        handler: _handler,
+        ..
+    } = MockEnv::with_client_builder(
+        ClusterClient::builder(vec![&*format!("redis://{name}")]).read_from_replicas(),
+        name,
+        move |received_cmd: &[u8], port| {
+            respond_startup_with_replica_using_config(name, received_cmd, None)?;
+            let cmd_str = std::str::from_utf8(received_cmd).unwrap();
+            if cmd_str.contains("ASKING") && port == 6382 {
+                asking_called_cloned.fetch_add(1, Ordering::Relaxed);
+            }
+            if port == 6380 && cmd_str.contains("baz") {
+                return Err(parse_redis_value(
+                    format!("-ASK 14000 {name}:6382\r\n").as_bytes(),
+                ));
+            }
+            let results = ["foo", "bar", "baz"]
+                .iter()
+                .filter_map(|expected_key| {
+                    if cmd_str.contains(expected_key) {
+                        Some(Value::Data(format!("{expected_key}-{port}").into_bytes()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            Err(Ok(Value::Bulk(results)))
+        },
+    );
+
+    let result = runtime
+        .block_on(cmd.query_async::<_, Vec<String>>(&mut connection))
+        .unwrap();
+    assert_eq!(result, vec!["foo-6382", "bar-6380", "baz-6382"]);
+    assert_eq!(asking_called.load(Ordering::Relaxed), 1);
 }
 
 #[test]


### PR DESCRIPTION
This means multi node operations now get error handling, and can trigger MOVED, etc.

Additionally, `func` was removed from `CmdArg::Cmd/Pipeline`. This removes the need 
to allocate a box on every request, and reduces code complexity by eliminating an
unnecessary generic type.