### PR TITLE
Changed deprecated rustls method

### DIFF
--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -674,7 +674,7 @@ impl ActualConnection {
 pub(crate) fn create_rustls_config(insecure: bool) -> RedisResult<rustls::ClientConfig> {
     let mut root_store = RootCertStore::empty();
     #[cfg(feature = "tls-rustls-webpki-roots")]
-    root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    root_store.add_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,


### PR DESCRIPTION
 Changed deprecated method rustls::RootCertStore::add_server_trust_anchors to add_trust_anchors