### PR TITLE
Added a check for DNS updates

### DIFF
--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "cluster-async")]
 mod support;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::{
     atomic::{self, AtomicI32, AtomicU16},
     atomic::{AtomicBool, Ordering},
@@ -242,13 +242,16 @@ struct ErrorConnection {
 }
 
 impl Connect for ErrorConnection {
-    fn connect<'a, T>(info: T, _socket_addr: Option<SocketAddr>) -> RedisFuture<'a, Self>
+    fn connect<'a, T>(
+        info: T,
+        _socket_addr: Option<SocketAddr>,
+    ) -> RedisFuture<'a, (Self, Option<IpAddr>)>
     where
         T: IntoConnectionInfo + Send + 'a,
     {
         Box::pin(async {
-            let inner = MultiplexedConnection::connect(info, None).await?;
-            Ok(ErrorConnection { inner })
+            let inner = MultiplexedConnection::connect(info, None).await?.0;
+            Ok((ErrorConnection { inner }, None))
         })
     }
 }


### PR DESCRIPTION
Before reusing an old connection, check if its node has encountered a DNS change, where the node's endpoint now leads to a different IP address.

Implementation detailes:
connect_simple now returns both the connection and an optional String with the connection IP (only valid for TCP connections, for Unix returns None). 
The cluster client now holds a ConnectionMap from the node's name to ClusterNode entries that holds both the connection and the IP. When we check if existing connection is valid in the get_or_create_conn function, we now also check if the node's address still points to the same IP.
