### PR TITLE
Changed CONFIG GET to be sent to a random node

### DIFF
--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -243,12 +243,10 @@ impl RoutingInfo {
 
             b"WAIT" => Some(Aggregate(AggregateOp::Min)),
 
-            b"CONFIG SET" | b"CONFIG GET" | b"CONFIG RESETSTAT" | b"CONFIG REWRITE"
-            | b"FLUSHALL" | b"FLUSHDB" | b"FUNCTION DELETE" | b"FUNCTION FLUSH"
-            | b"FUNCTION LOAD" | b"FUNCTION RESTORE" | b"LATENCY RESET" | b"MEMORY PURGE"
-            | b"MSET" | b"PING" | b"SCRIPT FLUSH" | b"SCRIPT LOAD" | b"SLOWLOG RESET" => {
-                Some(AllSucceeded)
-            }
+            b"CONFIG SET" | b"CONFIG RESETSTAT" | b"CONFIG REWRITE" | b"FLUSHALL" | b"FLUSHDB"
+            | b"FUNCTION DELETE" | b"FUNCTION FLUSH" | b"FUNCTION LOAD" | b"FUNCTION RESTORE"
+            | b"LATENCY RESET" | b"MEMORY PURGE" | b"MSET" | b"PING" | b"SCRIPT FLUSH"
+            | b"SCRIPT LOAD" | b"SLOWLOG RESET" => Some(AllSucceeded),
 
             b"KEYS" | b"MGET" | b"SLOWLOG GET" => Some(CombineArrays),
 
@@ -298,7 +296,7 @@ impl RoutingInfo {
             | b"MEMORY STATS"
             | b"INFO" => Some(RoutingInfo::MultiNode(MultipleNodeRoutingInfo::AllMasters)),
 
-            b"SLOWLOG GET" | b"SLOWLOG LEN" | b"SLOWLOG RESET" | b"CONFIG SET" | b"CONFIG GET"
+            b"SLOWLOG GET" | b"SLOWLOG LEN" | b"SLOWLOG RESET" | b"CONFIG SET"
             | b"CONFIG RESETSTAT" | b"CONFIG REWRITE" | b"SCRIPT FLUSH" | b"SCRIPT LOAD"
             | b"LATENCY RESET" | b"LATENCY GRAPH" | b"LATENCY HISTOGRAM" | b"LATENCY HISTORY"
             | b"LATENCY DOCTOR" | b"LATENCY LATEST" => {


### PR DESCRIPTION
 Removed CONFIG GET from AllNodes request policy and AllSucceeded response policy. CONFIG GET will be sent to a random node.