### PR TITLE
Fixed the initial nodes expander

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -395,7 +395,11 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             ref host,
             port,
             insecure,
+            socket_addr,
         } => {
+            if let Some(socket_addr) = socket_addr {
+                return <T>::connect_tcp_tls(host, socket_addr, insecure).await;
+            }
             let socket_addrs = get_socket_addrs(host, port).await?;
             select_ok(
                 socket_addrs.map(|socket_addr| <T>::connect_tcp_tls(host, socket_addr, insecure)),

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -27,6 +27,7 @@ use std::{
     iter::Iterator,
     marker::Unpin,
     mem,
+    net::SocketAddr,
     pin::Pin,
     sync::{
         atomic::{self, AtomicUsize},
@@ -489,9 +490,10 @@ where
 
     /// Go through each of the initial nodes and attempt to retrieve all IP entries from them.
     /// If there's a DNS endpoint that directs to several IP addresses, add all addresses to the initial nodes list.
+    /// Returns a vector of tuples, each containing a node's address (including the hostname) and its corresponding SocketAddr if retrieved.
     pub(crate) async fn try_to_expand_initial_nodes(
         initial_nodes: &[ConnectionInfo],
-    ) -> Vec<String> {
+    ) -> Vec<(String, Option<SocketAddr>)> {
         stream::iter(initial_nodes)
             .fold(
                 Vec::with_capacity(initial_nodes.len()),
@@ -502,22 +504,23 @@ where
                             host,
                             port,
                             insecure: _,
+                            socket_addr: _,
                         } => (host, port),
                         crate::ConnectionAddr::Unix(_) => {
                             // We don't support multiple addresses for a Unix address. Store the initial node address and continue
-                            acc.push(info.addr.to_string());
+                            acc.push((info.addr.to_string(), None));
                             return acc;
                         }
                     };
                     match get_socket_addrs(host, *port).await {
                         Ok(socket_addrs) => {
                             for addr in socket_addrs {
-                                acc.push(addr.to_string());
+                                acc.push((info.addr.to_string(), Some(addr)));
                             }
                         }
                         Err(_) => {
                             // Couldn't find socket addresses, store the initial node address and continue
-                            acc.push(info.addr.to_string());
+                            acc.push((info.addr.to_string(), None));
                         }
                     };
                     acc
@@ -530,14 +533,15 @@ where
         initial_nodes: &[ConnectionInfo],
         params: &ClusterParams,
     ) -> RedisResult<ConnectionMap<C>> {
-        let initial_nodes: Vec<String> = Self::try_to_expand_initial_nodes(initial_nodes).await;
+        let initial_nodes: Vec<(String, Option<SocketAddr>)> =
+            Self::try_to_expand_initial_nodes(initial_nodes).await;
         let connections = stream::iter(initial_nodes.iter().cloned())
-            .map(|addr| {
+            .map(|node| {
                 let params = params.clone();
                 async move {
-                    let result = connect_and_check(&addr, params).await;
+                    let result = connect_and_check(&node.0, params, node.1).await;
                     match result {
-                        Ok(conn) => Some((addr, async { conn }.boxed().shared())),
+                        Ok(conn) => Some((node.0, async { conn }.boxed().shared())),
                         Err(e) => {
                             trace!("Failed to connect to initial node: {:?}", e);
                             None
@@ -952,7 +956,7 @@ where
 
         let addr_conn_option = match conn {
             Some((addr, Some(conn))) => Some((addr, conn.await)),
-            Some((addr, None)) => connect_and_check(&addr, core.cluster_params.clone())
+            Some((addr, None)) => connect_and_check(&addr, core.cluster_params.clone(), None)
                 .await
                 .ok()
                 .map(|conn| (addr, conn)),
@@ -1119,10 +1123,10 @@ where
             let mut conn = conn.await;
             match check_connection(&mut conn, params.connection_timeout.into()).await {
                 Ok(_) => Ok(conn),
-                Err(_) => connect_and_check(addr, params.clone()).await,
+                Err(_) => connect_and_check(addr, params.clone(), None).await,
             }
         } else {
-            connect_and_check(addr, params.clone()).await
+            connect_and_check(addr, params.clone(), None).await
         }
     }
 }
@@ -1318,13 +1322,17 @@ impl Connect for MultiplexedConnection {
     }
 }
 
-async fn connect_and_check<C>(node: &str, params: ClusterParams) -> RedisResult<C>
+async fn connect_and_check<C>(
+    node: &str,
+    params: ClusterParams,
+    socket_addr: Option<SocketAddr>,
+) -> RedisResult<C>
 where
     C: ConnectionLike + Connect + Send + 'static,
 {
     let read_from_replicas = params.read_from_replicas;
     let connection_timeout = params.connection_timeout.into();
-    let info = get_connection_info(node, params)?;
+    let info = get_connection_info(node, params, socket_addr)?;
     let mut conn: C = C::connect(info).timeout(connection_timeout).await??;
     check_connection(&mut conn, connection_timeout).await?;
     if read_from_replicas {

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -147,6 +147,7 @@ impl ClusterClientBuilder {
                     host: _,
                     port: _,
                     insecure,
+                    socket_addr: _,
                 } => Some(match insecure {
                     false => TlsMode::Secure,
                     true => TlsMode::Insecure,

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -212,7 +212,7 @@ pub(crate) fn parse_slots(raw_slot_resp: &Value, tls: Option<TlsMode>) -> RedisR
                         } else {
                             return None;
                         };
-                        Some(get_connection_addr(ip.into_owned(), port, tls).to_string())
+                        Some(get_connection_addr(ip.into_owned(), port, tls, None).to_string())
                     } else {
                         None
                     }

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -49,6 +49,7 @@ impl ClusterType {
                 host: "127.0.0.1".into(),
                 port,
                 insecure: true,
+                socket_addr: None,
             },
         }
     }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -106,6 +106,7 @@ impl RedisServer {
                         host: "127.0.0.1".to_string(),
                         port: redis_port,
                         insecure: true,
+                        socket_addr: None,
                     }
                 } else {
                     redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), redis_port)
@@ -199,6 +200,7 @@ impl RedisServer {
                     host: host.clone(),
                     port,
                     insecure: true,
+                    socket_addr: None,
                 };
 
                 RedisServer {


### PR DESCRIPTION
 Fixed the initial nodes expander to return the socketAddr object and maintain the provided hostname, for TLS hostname verifications.
The Subject Alternative Name (SAN) is an extension to the X.509 specification that allows users to specify additional host names for a single SSL certificate. In ElastiCache cluster TLS certificate there is a subject name containing the suffix of the cluster name, e.g.: ```*.barshaul-babushka-standalone-test-tls.ez432c.use1.cache.amazonaws.com```. When we expand the DNS endpoint to multiple node addresses, we shall save the provided hostname in order to be able to verify the node with the TLS cert.