### PR TITLE
Fixed the initial nodes expander - option #2

### DIFF
--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -1,10 +1,10 @@
+use redis::cluster::{self, ClusterClient, ClusterClientBuilder};
 use std::{
     collections::HashMap,
+    net::SocketAddr,
     sync::{Arc, RwLock},
     time::Duration,
 };
-
-use redis::cluster::{self, ClusterClient, ClusterClientBuilder};
 
 use {
     once_cell::sync::Lazy,
@@ -32,7 +32,7 @@ pub struct MockConnection {
 
 #[cfg(feature = "cluster-async")]
 impl cluster_async::Connect for MockConnection {
-    fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
+    fn connect<'a, T>(info: T, _socket_addr: Option<SocketAddr>) -> RedisFuture<'a, Self>
     where
         T: IntoConnectionInfo + Send + 'a,
     {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "cluster-async")]
 mod support;
+use std::net::SocketAddr;
 use std::sync::{
     atomic::{self, AtomicI32, AtomicU16},
     atomic::{AtomicBool, Ordering},
@@ -241,12 +242,12 @@ struct ErrorConnection {
 }
 
 impl Connect for ErrorConnection {
-    fn connect<'a, T>(info: T) -> RedisFuture<'a, Self>
+    fn connect<'a, T>(info: T, _socket_addr: Option<SocketAddr>) -> RedisFuture<'a, Self>
     where
         T: IntoConnectionInfo + Send + 'a,
     {
         Box::pin(async {
-            let inner = MultiplexedConnection::connect(info).await?;
+            let inner = MultiplexedConnection::connect(info, None).await?;
             Ok(ErrorConnection { inner })
         })
     }


### PR DESCRIPTION
This option doesn't break the user facing API.

Fixed the initial nodes expander to return the socketAddr object and maintain the provided hostname, for TLS hostname verifications.
The Subject Alternative Name (SAN) is an extension to the X.509 specification that allows users to specify additional host names for a single SSL certificate. In ElastiCache cluster TLS certificate there is a subject name containing the suffix of the cluster name, e.g.: *.barshaul-babushka-standalone-test-tls.ez432c.use1.cache.amazonaws.com. When we expand the DNS endpoint to multiple node addresses, we shall save the provided hostname in order to be able to verify the node with the TLS cert.