### PR TITLE
Use the tracing crate instead of the log crate.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -85,7 +85,7 @@ serde_json = { version = "1.0.82", optional = true }
 # Optional aHash support
 ahash = { version = "0.7.6", optional = true }
 
-log = { version = "0.4", optional = true }
+tracing = "0.1"
 futures-time = { version = "3.0.0", optional = true }
 
 [features]
@@ -108,7 +108,7 @@ tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
 connection-manager = ["arc-swap", "futures", "aio", "tokio-retry"]
 streams = []
-cluster-async = ["cluster", "futures", "futures-util", "log"]
+cluster-async = ["cluster", "futures", "futures-util"]
 keep-alive = ["socket2"]
 sentinel = ["rand"]
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -73,13 +73,13 @@ use futures::{
     ready, stream,
 };
 use futures_time::future::FutureExt;
-use log::trace;
 use pin_project_lite::pin_project;
 use tokio::sync::{
     mpsc,
     oneshot::{self, Receiver},
     RwLock,
 };
+use tracing::trace;
 
 use self::connections_container::{ConnectionAndIdentifier, Identifier as ConnectionIdentifier};
 

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -7,13 +7,13 @@ use crate::cluster_routing::SlotAddr;
 use crate::cluster_routing::SlotAddrs;
 use crate::{cluster::TlsMode, cluster_routing::Slot, ErrorKind, RedisError, RedisResult, Value};
 use derivative::Derivative;
-use log::trace;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
+use tracing::trace;
 
 /// The default number of refersh topology retries
 pub const DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES: usize = 3;

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -179,7 +179,7 @@ async fn test_failover(env: &TestClusterContext, requests: i32, value: i32) {
             Ok(()) => break 'outer,
             Err(err) => {
                 // Failed to clear the databases, retry
-                log::warn!("{}", err);
+                tracing::warn!("{}", err);
             }
         }
     }


### PR DESCRIPTION
This will allow us to handle the traces with logger_core.