### PR TITLE
Added periodic topology checks

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -43,6 +43,8 @@ pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time"], optional = true }
 socket2 = { version = "0.4", default-features = false, optional = true }
+fast-math = { version = "0.1.1", optional = true }
+dispose = { version = "0.5.0", optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.1.0", optional = true }
@@ -92,7 +94,7 @@ arcstr = "1.1.5"
 [features]
 default = ["acl", "streams", "geospatial", "script", "keep-alive"]
 acl = []
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait", "futures-time"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio", "async-trait", "futures-time", "fast-math", "dispose"]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand", "derivative"]

--- a/redis/src/cluster_async/connections_container.rs
+++ b/redis/src/cluster_async/connections_container.rs
@@ -5,7 +5,7 @@ use arcstr::ArcStr;
 use rand::seq::IteratorRandom;
 
 use crate::cluster_routing::{MultipleNodeRoutingInfo, Route, SlotAddr};
-use crate::cluster_topology::{ReadFromReplicaStrategy, SlotMap, SlotMapValue};
+use crate::cluster_topology::{ReadFromReplicaStrategy, SlotMap, SlotMapValue, TopologyHash};
 
 type IdentifierType = ArcStr;
 
@@ -32,6 +32,7 @@ pub(crate) struct ConnectionsContainer<Connection> {
     connection_map: HashMap<Identifier, Option<ClusterNode<Connection>>>,
     slot_map: SlotMap,
     read_from_replica_strategy: ReadFromReplicaStrategy,
+    topology_hash: TopologyHash,
 }
 
 impl<Connection> Default for ConnectionsContainer<Connection> {
@@ -40,6 +41,7 @@ impl<Connection> Default for ConnectionsContainer<Connection> {
             connection_map: Default::default(),
             slot_map: Default::default(),
             read_from_replica_strategy: ReadFromReplicaStrategy::AlwaysFromPrimary,
+            topology_hash: 0,
         }
     }
 }
@@ -54,6 +56,7 @@ where
         slot_map: SlotMap,
         connection_map: HashMap<ArcStr, ClusterNode<Connection>>,
         read_from_replica_strategy: ReadFromReplicaStrategy,
+        topology_hash: TopologyHash,
     ) -> Self {
         Self {
             connection_map: connection_map
@@ -62,6 +65,7 @@ where
                 .collect(),
             slot_map,
             read_from_replica_strategy,
+            topology_hash,
         }
     }
 
@@ -221,6 +225,10 @@ where
             .filter(|(_, conn_option)| conn_option.is_some())
             .count()
     }
+
+    pub(crate) fn get_current_topology_hash(&self) -> TopologyHash {
+        self.topology_hash
+    }
 }
 
 #[cfg(test)]
@@ -310,6 +318,7 @@ mod tests {
             slot_map,
             connection_map,
             read_from_replica_strategy: stragey,
+            topology_hash: 0,
         }
     }
 

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -32,7 +32,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::{
-        atomic::{self, AtomicUsize},
+        atomic::{self, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     task::{self, Poll},
@@ -48,12 +48,13 @@ use crate::{
         SingleNodeRoutingInfo,
     },
     cluster_topology::{
-        calculate_topology, DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL,
-        DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT,
+        calculate_topology, DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES,
+        DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL, DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT,
     },
     Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisFuture, RedisResult,
     Value,
 };
+use std::time::Duration;
 
 #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
 use crate::aio::{async_std::AsyncStd, RedisRuntime};
@@ -68,13 +69,15 @@ use backoff_tokio::future::retry;
 #[cfg(feature = "tokio-comp")]
 use backoff_tokio::{Error, ExponentialBackoff};
 
+use dispose::{Disposable, Dispose};
 use futures::{
     future::{self, BoxFuture},
     prelude::*,
     ready, stream,
 };
-use futures_time::future::FutureExt;
+use futures_time::{future::FutureExt, task::sleep};
 use pin_project_lite::pin_project;
+use std::sync::atomic::AtomicBool;
 use tokio::sync::{
     mpsc,
     oneshot::{self, Receiver},
@@ -198,6 +201,7 @@ struct InnerCore<C> {
     conn_lock: RwLock<ConnectionsContainer<C>>,
     cluster_params: ClusterParams,
     pending_requests: Mutex<Vec<PendingRequest<Response, C>>>,
+    slot_refresh_in_progress: AtomicBool,
 }
 
 type Core<C> = Arc<InnerCore<C>>;
@@ -212,6 +216,14 @@ struct ClusterConnInner<C> {
         >,
     >,
     refresh_error: Option<RedisError>,
+    // A flag indicating the connection's closure and the requirement to shut down all related tasks.
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl<C> Dispose for ClusterConnInner<C> {
+    fn dispose(self) {
+        self.shutdown_flag.store(true, Ordering::Relaxed);
+    }
 }
 
 #[derive(Clone)]
@@ -478,25 +490,42 @@ where
     async fn new(
         initial_nodes: &[ConnectionInfo],
         cluster_params: ClusterParams,
-    ) -> RedisResult<Self> {
+    ) -> RedisResult<Disposable<Self>> {
         let connections = Self::create_initial_connections(initial_nodes, &cluster_params).await?;
+        let topology_checks_interval = cluster_params.topology_checks_interval;
         let inner = Arc::new(InnerCore {
             conn_lock: RwLock::new(ConnectionsContainer::new(
                 Default::default(),
                 connections,
                 cluster_params.read_from_replicas,
+                0,
             )),
             cluster_params,
             pending_requests: Mutex::new(Vec::new()),
+            slot_refresh_in_progress: AtomicBool::new(false),
         });
-        let mut connection = ClusterConnInner {
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let connection = ClusterConnInner {
             inner,
             in_flight_requests: Default::default(),
             refresh_error: None,
             state: ConnectionState::PollComplete,
+            shutdown_flag: shutdown_flag.clone(),
         };
-        connection.refresh_slots_with_retries().await?;
-        Ok(connection)
+        Self::refresh_slots_with_retries(connection.inner.clone()).await?;
+        if let Some(duration) = topology_checks_interval {
+            let periodic_task = ClusterConnInner::periodic_topology_check(
+                connection.inner.clone(),
+                duration,
+                shutdown_flag,
+            );
+            #[cfg(feature = "tokio-comp")]
+            tokio::spawn(periodic_task);
+            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+            AsyncStd::spawn(periodic_task);
+        }
+
+        Ok(Disposable::new(connection))
     }
 
     /// Go through each of the initial nodes and attempt to retrieve all IP entries from them.
@@ -700,26 +729,87 @@ where
     }
 
     // Query a node to discover slot-> master mappings with retries
-    fn refresh_slots_with_retries(&mut self) -> impl Future<Output = RedisResult<()>> {
-        let inner = self.inner.clone();
-        async move {
+    async fn refresh_slots_with_retries(inner: Arc<InnerCore<C>>) -> RedisResult<()> {
+        if inner
+            .slot_refresh_in_progress
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return Ok(());
+        }
+        let retry_strategy = ExponentialBackoff {
+            initial_interval: DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL,
+            max_interval: DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT,
+            ..Default::default()
+        };
+        let retries_counter = AtomicUsize::new(0);
+        let res = retry(retry_strategy, || {
+            let curr_retry = retries_counter.fetch_add(1, atomic::Ordering::Relaxed);
+            Self::refresh_slots(inner.clone(), curr_retry).map_err(Error::from)
+        })
+        .await;
+        inner
+            .slot_refresh_in_progress
+            .store(false, Ordering::Relaxed);
+        res
+    }
+
+    async fn periodic_topology_check(
+        inner: Arc<InnerCore<C>>,
+        interval_duration: Duration,
+        shutdown_flag: Arc<AtomicBool>,
+    ) {
+        loop {
+            if shutdown_flag.load(Ordering::Relaxed) {
+                return;
+            }
+            let _ = sleep(interval_duration.into()).await;
+
             let retry_strategy = ExponentialBackoff {
                 initial_interval: DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL,
                 max_interval: DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT,
                 ..Default::default()
             };
-            let retries_counter = AtomicUsize::new(0);
-            retry(retry_strategy, || {
-                retries_counter.fetch_add(1, atomic::Ordering::Relaxed);
-                Self::refresh_slots(
-                    inner.clone(),
-                    retries_counter.load(atomic::Ordering::Relaxed),
-                )
-                .map_err(Error::from)
+            let topology_check_res = retry(retry_strategy, || {
+                Self::check_for_topology_diff(inner.clone()).map_err(Error::from)
             })
-            .await?;
-            Ok(())
+            .await;
+            if let Ok(true) = topology_check_res {
+                let _ = Self::refresh_slots_with_retries(inner.clone()).await;
+            };
         }
+    }
+
+    /// Queries log2n nodes (where n represents the number of cluster nodes) to determine whether their
+    /// topology view differs from the one currently stored in the connection manager.
+    /// Returns true if change was detected, otherwise false.
+    async fn check_for_topology_diff(inner: Arc<InnerCore<C>>) -> RedisResult<bool> {
+        let read_guard = inner.conn_lock.read().await;
+        let num_of_nodes: usize = read_guard.len();
+        // TODO: Starting from Rust V1.67, integers has logarithms support.
+        // When we no longer need to support Rust versions < 1.67, remove fast_math and transition to the ilog2 function.
+        let num_of_nodes_to_query =
+            std::cmp::max(fast_math::log2_raw(num_of_nodes as f32) as usize, 1);
+        let requested_nodes = read_guard.random_connections(num_of_nodes_to_query);
+        let topology_join_results =
+            futures::future::join_all(requested_nodes.map(|conn| async move {
+                let mut conn: C = conn.1.await;
+                conn.req_packed_command(&slot_cmd()).await
+            }))
+            .await;
+        let topology_values: Vec<_> = topology_join_results
+            .into_iter()
+            .filter_map(|r| r.ok())
+            .collect();
+        let (_, found_topology_hash) = calculate_topology(
+            topology_values,
+            DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES,
+            inner.cluster_params.tls,
+            num_of_nodes_to_query,
+            inner.cluster_params.read_from_replicas,
+        )?;
+        let change_found = read_guard.get_current_topology_hash() != found_topology_hash;
+        Ok(change_found)
     }
 
     // Query a node to discover slot-> master mappings
@@ -739,7 +829,7 @@ where
             .into_iter()
             .filter_map(|r| r.ok())
             .collect();
-        let new_slots = calculate_topology(
+        let (new_slots, topology_hash) = calculate_topology(
             topology_values,
             curr_retry,
             inner.cluster_params.tls,
@@ -799,6 +889,7 @@ where
             new_slots,
             new_connections,
             inner.cluster_params.read_from_replicas,
+            topology_hash,
         );
         Ok(())
     }
@@ -1075,7 +1166,7 @@ where
                 }
                 Poll::Ready(Err(err)) => {
                     self.state = ConnectionState::Recover(RecoverFuture::RecoverSlots(Box::pin(
-                        self.refresh_slots_with_retries(),
+                        Self::refresh_slots_with_retries(self.inner.clone()),
                     )));
                     Poll::Ready(Err(err))
                 }
@@ -1250,7 +1341,7 @@ impl PollFlushAction {
     }
 }
 
-impl<C> Sink<Message<C>> for ClusterConnInner<C>
+impl<C> Sink<Message<C>> for Disposable<ClusterConnInner<C>>
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + Unpin + 'static,
 {
@@ -1332,9 +1423,10 @@ where
                 ConnectionState::PollComplete => match ready!(self.poll_complete(cx)) {
                     PollFlushAction::None => return Poll::Ready(Ok(())),
                     PollFlushAction::RebuildSlots => {
-                        self.state = ConnectionState::Recover(RecoverFuture::RecoverSlots(
-                            Box::pin(self.refresh_slots_with_retries()),
-                        ));
+                        self.state =
+                            ConnectionState::Recover(RecoverFuture::RecoverSlots(Box::pin(
+                                ClusterConnInner::refresh_slots_with_retries(self.inner.clone()),
+                            )));
                     }
                     PollFlushAction::Reconnect(identifiers) => {
                         self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -21,6 +21,7 @@ struct BuilderParams {
     tls: Option<TlsMode>,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
+    topology_checks_interval: Option<Duration>,
 }
 
 #[derive(Clone)]
@@ -72,6 +73,7 @@ pub(crate) struct ClusterParams {
     pub(crate) tls: Option<TlsMode>,
     pub(crate) retry_params: RetryParams,
     pub(crate) connection_timeout: Duration,
+    pub(crate) topology_checks_interval: Option<Duration>,
 }
 
 impl From<BuilderParams> for ClusterParams {
@@ -83,6 +85,7 @@ impl From<BuilderParams> for ClusterParams {
             tls: value.tls,
             retry_params: value.retries_configuration,
             connection_timeout: value.connection_timeout.unwrap_or(Duration::MAX),
+            topology_checks_interval: value.topology_checks_interval,
         }
     }
 }
@@ -247,6 +250,17 @@ impl ClusterClientBuilder {
     /// If enabled, the cluster will only wait the given time on each connection attempt to each node.
     pub fn connection_timeout(mut self, connection_timeout: Duration) -> ClusterClientBuilder {
         self.builder_params.connection_timeout = Some(connection_timeout);
+        self
+    }
+
+    /// Enables periodic topology checks for this client.
+    ///
+    /// If enabled, periodic topology checks will be executed at the configured intervals to examine whether there
+    /// have been any changes in the cluster's topology. If a change is detected, it will trigger a slot refresh.
+    /// Unlike slot refreshments, the periodic topology checks only examine a limited number of nodes to query their
+    /// topology, ensuring that the check remains quick and efficient.
+    pub fn periodic_topology_checks(mut self, interval: Duration) -> ClusterClientBuilder {
+        self.builder_params.topology_checks_interval = Some(interval);
         self
     }
 

--- a/redis/src/cluster_topology.rs
+++ b/redis/src/cluster_topology.rs
@@ -18,12 +18,13 @@ pub const DEFAULT_REFRESH_SLOTS_RETRY_TIMEOUT: Duration = Duration::from_secs(1)
 pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub(crate) const SLOT_SIZE: u16 = 16384;
+pub(crate) type TopologyHash = u64;
 
 #[derive(Derivative)]
 #[derivative(PartialEq, Eq)]
 #[derive(Debug)]
 pub(crate) struct TopologyView {
-    pub(crate) hash_value: u64,
+    pub(crate) hash_value: TopologyHash,
     #[derivative(PartialEq = "ignore")]
     pub(crate) topology_value: Value,
     #[derivative(PartialEq = "ignore")]
@@ -282,7 +283,7 @@ pub(crate) fn calculate_topology(
     tls_mode: Option<TlsMode>,
     num_of_queried_nodes: usize,
     read_from_replica: ReadFromReplicaStrategy,
-) -> Result<SlotMap, RedisError> {
+) -> Result<(SlotMap, TopologyHash), RedisError> {
     if topology_views.is_empty() {
         return Err(RedisError::from((
             ErrorKind::ResponseError,
@@ -355,7 +356,10 @@ pub(crate) fn calculate_topology(
                 "Failed to parse the slots on the majority view",
             )))?;
 
-        Ok(SlotMap::new(slots_data, read_from_replica))
+        Ok((
+            SlotMap::new(slots_data, read_from_replica),
+            most_frequent_topology.hash_value,
+        ))
     };
 
     if non_unique_max_node_count {
@@ -471,7 +475,7 @@ mod tests {
             get_view(&ViewType::SingleNodeViewFullCoverage),
             get_view(&ViewType::TwoNodesViewFullCoverage),
         ];
-        let topology_view = calculate_topology(
+        let (topology_view, _) = calculate_topology(
             topology_results,
             1,
             None,
@@ -513,7 +517,7 @@ mod tests {
             get_view(&ViewType::TwoNodesViewFullCoverage),
             get_view(&ViewType::TwoNodesViewMissingSlots),
         ];
-        let topology_view = calculate_topology(
+        let (topology_view, _) = calculate_topology(
             topology_results,
             3,
             None,
@@ -536,7 +540,7 @@ mod tests {
             get_view(&ViewType::TwoNodesViewFullCoverage),
             get_view(&ViewType::TwoNodesViewMissingSlots),
         ];
-        let topology_view = calculate_topology(
+        let (topology_view, _) = calculate_topology(
             topology_results,
             1,
             None,
@@ -560,7 +564,7 @@ mod tests {
             get_view(&ViewType::SingleNodeViewMissingSlots),
             get_view(&ViewType::TwoNodesViewMissingSlots),
         ];
-        let topology_view = calculate_topology(
+        let (topology_view, _) = calculate_topology(
             topology_results,
             1,
             None,
@@ -584,7 +588,7 @@ mod tests {
             get_view(&ViewType::TwoNodesViewMissingSlots),
             get_view(&ViewType::SingleNodeViewMissingSlots),
         ];
-        let topology_view = calculate_topology(
+        let (topology_view, _) = calculate_topology(
             topology_results,
             1,
             None,


### PR DESCRIPTION
This PR adds an optional periodic topology checks to the async cluster client. 
The current periodic check use the user's connections. On the next PR I will add management connections that will be used for this checks. 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/barshaul/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/barshaul/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"0\.000";}
.xl66
	{mso-number-format:0;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



language | clientCount | data_size | num_of_tasks | Average of get_existing_std_dev | Average of set_average_latency | Average of tps | TPS diff | SET avg latency diff | GET avg latency diff
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
mainline | 1 | 100 | 1 | 0.087 | 0.230 | 4315 |   |   |  
mainline | 1 | 100 | 10 | 0.166 | 0.392 | 25265 |   |   |  
mainline | 1 | 100 | 100 | 0.587 | 1.057 | 94161 |   |   |  
mainline | 1 | 100 | 1000 | 2.217 | 6.628 | 150777 |   |   |  
mainline | 1 | 4000 | 1 | 0.035 | 0.265 | 4597 |   |   |  
mainline | 1 | 4000 | 10 | 0.124 | 0.431 | 24015 |   |   |  
mainline | 1 | 4000 | 100 | 0.164 | 0.912 | 110168 |   |   |  
mainline | 1 | 4000 | 1000 | 1.008 | 7.443 | 134527 |   |   |  
periodic-60-sec | 1 | 100 | 1 | 0.072 | 0.232 | 4318 | 1.001 | 1.006 | 0.831
periodic-60-sec | 1 | 100 | 10 | 0.220 | 0.467 | 21419 | 0.848 | 1.193 | 1.323
periodic-60-sec | 1 | 100 | 100 | 0.561 | 1.070 | 93152 | 0.989 | 1.012 | 0.956
periodic-60-sec | 1 | 100 | 1000 | 2.201 | 6.594 | 151617 | 1.006 | 0.995 | 0.993
periodic-60-sec | 1 | 4000 | 1 | 0.032 | 0.274 | 4390 | 0.955 | 1.033 | 0.934
periodic-60-sec | 1 | 4000 | 10 | 0.123 | 0.430 | 24181 | 1.007 | 0.998 | 0.988
periodic-60-sec | 1 | 4000 | 100 | 0.177 | 0.896 | 111774 | 1.015 | 0.983 | 1.079
periodic-60-sec | 1 | 4000 | 1000 | 0.994 | 7.220 | 138587 | 1.030 | 0.970 | 0.987



</body>

</html>
