### PR TITLE
Fixed the initial connection map 

### DIFF
--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -583,9 +583,14 @@ where
                 let params = params.clone();
                 async move {
                     let result = connect_and_check(&node_addr, params, socket_addr).await;
+                    let node_identifier = if let Some(socket_addr) = socket_addr {
+                        socket_addr.to_string()
+                    } else {
+                        node_addr
+                    };
                     result.map(|(conn, ip)| {
                         (
-                            node_addr,
+                            node_identifier,
                             ClusterNode::new(async { conn }.boxed().shared(), ip),
                         )
                     })

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1752,7 +1752,7 @@ implement_commands! {
     ///     STREAMS key_1 key_2 ... key_N
     ///     ID_1 ID_2 ... ID_N
     ///
-    /// XREADGROUP [BLOCK <milliseconds>] [COUNT <count>] [NOACK] [GROUP group-name consumer-name]
+    /// XREADGROUP [GROUP group-name consumer-name] [BLOCK <milliseconds>] [COUNT <count>] [NOACK] 
     ///     STREAMS key_1 key_2 ... key_N
     ///     ID_1 ID_2 ... ID_N
     /// ```

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -179,6 +179,16 @@ impl ToRedisArgs for StreamReadOptions {
     where
         W: ?Sized + RedisWrite,
     {
+        if let Some(ref group) = self.group {
+            out.write_arg(b"GROUP");
+            for i in &group.0 {
+                out.write_arg(i);
+            }
+            for i in &group.1 {
+                out.write_arg(i);
+            }
+        }
+
         if let Some(ref ms) = self.block {
             out.write_arg(b"BLOCK");
             out.write_arg(format!("{ms}").as_bytes());
@@ -189,18 +199,10 @@ impl ToRedisArgs for StreamReadOptions {
             out.write_arg(format!("{n}").as_bytes());
         }
 
-        if let Some(ref group) = self.group {
+        if self.group.is_some() {
             // noack is only available w/ xreadgroup
             if self.noack == Some(true) {
                 out.write_arg(b"NOACK");
-            }
-
-            out.write_arg(b"GROUP");
-            for i in &group.0 {
-                out.write_arg(i);
-            }
-            for i in &group.1 {
-                out.write_arg(i);
             }
         }
     }

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -74,14 +74,14 @@ fn test_cmd_options() {
 
     assert_args!(
         &opts,
+        "GROUP",
+        "group-name",
+        "consumer-name",
         "BLOCK",
         "100",
         "COUNT",
         "200",
-        "NOACK",
-        "GROUP",
-        "group-name",
-        "consumer-name"
+        "NOACK"
     );
 
     // should skip noack because of missing group(,)


### PR DESCRIPTION
Fixed the initial connection map in the cluster to use the direct IP address when available as a key, rather than using the DNS entry.

Rebased over #58 