### PR TITLE
Fix linter, cherry pick from upstream

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1752,7 +1752,7 @@ implement_commands! {
     ///     STREAMS key_1 key_2 ... key_N
     ///     ID_1 ID_2 ... ID_N
     ///
-    /// XREADGROUP [BLOCK <milliseconds>] [COUNT <count>] [NOACK] [GROUP group-name consumer-name]
+    /// XREADGROUP [GROUP group-name consumer-name] [BLOCK <milliseconds>] [COUNT <count>] [NOACK] 
     ///     STREAMS key_1 key_2 ... key_N
     ///     ID_1 ID_2 ... ID_N
     /// ```

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -883,7 +883,7 @@ pub trait ConnectionLike {
         count: usize,
     ) -> RedisResult<Vec<Value>>;
 
-    /// Sends a [Cmd](Cmd) into the TCP socket and reads a single response from it.
+    /// Sends a [Cmd] into the TCP socket and reads a single response from it.
     fn req_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
         let pcmd = cmd.get_packed_command();
         self.req_packed_command(&pcmd)

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -179,6 +179,16 @@ impl ToRedisArgs for StreamReadOptions {
     where
         W: ?Sized + RedisWrite,
     {
+        if let Some(ref group) = self.group {
+            out.write_arg(b"GROUP");
+            for i in &group.0 {
+                out.write_arg(i);
+            }
+            for i in &group.1 {
+                out.write_arg(i);
+            }
+        }
+
         if let Some(ref ms) = self.block {
             out.write_arg(b"BLOCK");
             out.write_arg(format!("{ms}").as_bytes());
@@ -189,18 +199,10 @@ impl ToRedisArgs for StreamReadOptions {
             out.write_arg(format!("{n}").as_bytes());
         }
 
-        if let Some(ref group) = self.group {
+        if self.group.is_some() {
             // noack is only available w/ xreadgroup
             if self.noack == Some(true) {
                 out.write_arg(b"NOACK");
-            }
-
-            out.write_arg(b"GROUP");
-            for i in &group.0 {
-                out.write_arg(i);
-            }
-            for i in &group.1 {
-                out.write_arg(i);
             }
         }
     }

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -74,14 +74,14 @@ fn test_cmd_options() {
 
     assert_args!(
         &opts,
+        "GROUP",
+        "group-name",
+        "consumer-name",
         "BLOCK",
         "100",
         "COUNT",
         "200",
-        "NOACK",
-        "GROUP",
-        "group-name",
-        "consumer-name"
+        "NOACK"
     );
 
     // should skip noack because of missing group(,)


### PR DESCRIPTION
Fix XREADGROUP command ordering as per Redis Docs, and compatibility with Upstash Redis (#960)