### PR TITLE
ConnectionManager: Reconnect when RESP3 is set.

### DIFF
--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -564,9 +564,7 @@ impl ConnectionManager {
             if let Some(sender) = external_sender.as_ref() {
                 if let Err(err) = sender.send(push_info) {
                     if err.is_permanent() {
-                        external_sender.take();
-                    } else {
-                        return Err(err);
+                        return Err(external_sender.take());
                     }
                 }
             }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -554,8 +554,10 @@ impl ConnectionManager {
                 this.reconnect(this.0.connection.load());
             }
             if let Some(sender) = external_sender.as_ref() {
-                if sender.send(push_info).is_err() {
-                    external_sender.take();
+                if let Err(err) = sender.send(push_info) {
+                    if err.is_permanent() {
+                        external_sender.take();
+                    }
                 }
             }
         }

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::Mutex;
 
+type OptionalPushSender = Option<Arc<dyn AsyncPushSender>>;
+
 /// The configuration for reconnect mechanism and request timing for the [ConnectionManager]
 #[derive(Clone)]
 pub struct ConnectionManagerConfig {
@@ -543,7 +545,7 @@ impl ConnectionManager {
         receiver: oneshot::Receiver<(
             ConnectionManager,
             UnboundedReceiver<PushInfo>,
-            Option<Arc<dyn AsyncPushSender>>,
+            OptionalPushSender,
         )>,
     ) {
         let Ok((this, mut internal_receiver, mut external_sender)) = receiver.await else {

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -243,7 +243,7 @@ impl<T, Func: Fn(PushInfo) -> Result<(), T> + Send + Sync + 'static> AsyncPushSe
     fn send(&self, info: PushInfo) -> Result<(), SendError> {
         match self(info) {
             Ok(_) => Ok(()),
-            Err(_) => Err(SendError::new(true)),
+            Err(_) => Err(SendError::new(false)),
         }
     }
 }

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1849,7 +1849,7 @@ mod basic_async {
         impl AsyncPushSender for Sender {
             fn send(&self, push: PushInfo) -> Result<(), redis::aio::SendError> {
                 self.sender.send(push).unwrap();
-                Err(redis::aio::SendError)
+                Err(redis::aio::SendError::new(false))
             }
         }
 
@@ -1884,7 +1884,7 @@ mod basic_async {
 
                 // drop again, to verify that the mechanism works even after the sender returned an error.
                 drop(_ctx);
-                assert!(rx.try_recv().is_err());
+                assert_eq!(push.kind, PushKind::Disconnection);
                 let _ctx = TestContext::new_with_addr(addr);
 
                 assert!(rx.try_recv().is_err());

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1797,20 +1797,17 @@ mod basic_async {
     #[cfg(feature = "connection-manager")]
     #[rstest]
     #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
-    #[case::async_std(RuntimeType::AsyncStd)]
-    fn manager_should_reconnect_without_actions_if_push_sender_is_set(
-        #[case] runtime: RuntimeType,
-    ) {
+    #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn manager_should_reconnect_without_actions_if_resp3_is_set(#[case] runtime: RuntimeType) {
         let ctx = TestContext::new();
         if ctx.protocol == ProtocolVersion::RESP2 {
             return;
         }
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         let max_delay_between_attempts = 2;
         let config = redis::aio::ConnectionManagerConfig::new()
             .set_factor(10000)
-            .set_push_sender(tx)
             .set_max_delay(max_delay_between_attempts);
 
         block_on_all(
@@ -1822,11 +1819,76 @@ mod basic_async {
 
                 let addr = ctx.server.client_addr().clone();
                 drop(ctx);
+                let _ctx = TestContext::new_with_addr(addr);
+
+                sleep(Duration::from_secs_f32(0.01).into()).await;
+
+                assert!(cmd("PING").exec_async(&mut conn).await.is_ok());
+
+                Ok::<_, RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[cfg(feature = "connection-manager")]
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "async-std-comp", case::async_std(RuntimeType::AsyncStd))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error(
+        #[case] runtime: RuntimeType,
+    ) {
+        use redis::{aio::AsyncPushSender, PushInfo};
+
+        struct Sender {
+            sender: tokio::sync::mpsc::UnboundedSender<PushInfo>,
+        }
+
+        impl AsyncPushSender for Sender {
+            fn send(&self, push: PushInfo) -> Result<(), redis::aio::SendError> {
+                self.sender.send(push).unwrap();
+                Err(redis::aio::SendError)
+            }
+        }
+
+        let ctx = TestContext::new();
+        if ctx.protocol == ProtocolVersion::RESP2 {
+            return;
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let max_delay_between_attempts = 2;
+        let config = redis::aio::ConnectionManagerConfig::new()
+            .set_factor(10000)
+            .set_push_sender(Sender { sender: tx })
+            .set_max_delay(max_delay_between_attempts);
+
+        block_on_all(
+            async move {
+                let mut conn = ctx
+                    .client
+                    .get_connection_manager_with_config(config)
+                    .await?;
+
+                let addr = ctx.server.client_addr().clone();
+                // drop once, to trigger reconnect and sending the push message
+                drop(ctx);
                 let push = rx.recv().await.unwrap();
                 assert_eq!(push.kind, PushKind::Disconnection);
+                let _ctx = TestContext::new_with_addr(addr.clone());
+
+                assert!(rx.try_recv().is_err());
+                assert!(cmd("PING").exec_async(&mut conn).await.is_ok());
+
+                // drop again, to verify that the mechanism works even after the sender returned an error.
+                drop(_ctx);
+                assert!(rx.try_recv().is_err());
                 let _ctx = TestContext::new_with_addr(addr);
 
                 assert!(rx.try_recv().is_err());
+                sleep(Duration::from_secs_f32(0.01).into()).await;
                 assert!(cmd("PING").exec_async(&mut conn).await.is_ok());
 
                 Ok::<_, RedisError>(())


### PR DESCRIPTION
This changes the behavior of the connection manager, so that if it was configured with RESP3 but without a push sender, or with a push sender after it returned an error, it would still handle disconnect messages from the underlying connection and reconnect without a user request.

#1610- **ConnectionManager: Reconnect when RESP3 is set.**
- **Remove assumption that errors mean that all future requests will fail.**
- **Push sender termination**
